### PR TITLE
react 17 support in peerDeependencies and devDependencies (fix for issue #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1 || ^17.0.0",
+    "react": ">=16.8.1",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {
-    "react": "^16.9.0 || ^17.0.0",
+    "react": ">=16.9.0",
     "react-native": "^0.61.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.8.1",
+    "react": "^16.8.1 || ^17.0.0",
     "react-native": ">=0.60.0-rc.0 <1.0.x"
   },
   "devDependencies": {
-    "react": "^16.9.0",
+    "react": "^16.9.0 || ^17.0.0",
     "react-native": "^0.61.5"
   }
 }


### PR DESCRIPTION
Fixing an error (issue #6) that happens when trying to install `react-native-simple-biometrics` in a new React Native project that support React 17.

The fix has been tested and it works flawlessly.